### PR TITLE
Fix a bug when report crash doesn't have a message

### DIFF
--- a/pytest_csv/column/_builtin.py
+++ b/pytest_csv/column/_builtin.py
@@ -82,7 +82,7 @@ def column_message(item, report):
         if hasattr(report, 'wasxfail'):
             yield MESSAGE, report.wasxfail
         else:
-            if hasattr(report.longrepr, 'reprcrash'):
+            if hasattr(report.longrepr, 'reprcrash') and hasattr(report.longrepr.reprcrash, 'message'):
                 yield MESSAGE, report.longrepr.reprcrash.message
             elif isinstance(report.longrepr, six.string_types):
                 yield MESSAGE, report.longrepr

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -29,16 +29,18 @@ __TAB_ARGS__ = dict(tablefmt='grid', headers='keys', showindex='always')
 
 
 def assert_outcomes(result, passed=0, skipped=0, failed=0, error=0, xpassed=0, xfailed=0):
-    if LooseVersion(pytest_version) < LooseVersion('3.8'):
-        result.assert_outcomes(passed=passed,
-                               skipped=skipped,
-                               failed=failed,
-                               error=error)
-    else:
+    if LooseVersion(pytest_version) < LooseVersion('6.0'):
         result.assert_outcomes(passed=passed,
                                skipped=skipped,
                                failed=failed,
                                error=error,
+                               xpassed=xpassed,
+                               xfailed=xfailed)
+    else:
+        result.assert_outcomes(passed=passed,
+                               skipped=skipped,
+                               failed=failed,
+                               errors=error,
                                xpassed=xpassed,
                                xfailed=xfailed)
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -70,3 +70,28 @@ def test_xfail_with_message(testdir):
         (MESSAGE, r'.*this test is expected to fail.*'),
         (DURATION, r'.*'),
     ])
+
+
+def test_fail_with_message_without_trace(testdir):
+    testdir.makepyfile('''
+        import pytest
+
+        def test_01():
+            pytest.fail('this test fails', pytrace=False)
+    ''')
+
+    result = testdir.runpytest('--csv', 'tests.csv')
+
+    assert_outcomes(result, failed=1)
+
+    assert_csv_equal('tests.csv', [
+        (ID, '.*test_fail_with_message_without_trace.py::test_01'),
+        (MODULE, r'.*test_fail_with_message_without_trace'),
+        (NAME, 'test_01'),
+        (FILE, r'.*test_fail_with_message_without_trace.py'),
+        (DOC, ''),
+        (MARKERS, ''),
+        (STATUS, FAILED),
+        (MESSAGE, r'.*this test fails.*'),
+        (DURATION, r'.*'),
+    ])

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@
 # ----------------------------------------------------------------------
 
 [tox]
-envlist = py{27,34,35,36,37,38,py,py3}-pytest{44,45,46,50,51}x
+envlist = py{27,34,35,36,37,38,py,py3}-pytest{44,45,46,50,51,60,61}x
 
 [testenv]
 deps = pytest44x: pytest>=4.4,<4.5
@@ -25,5 +25,7 @@ deps = pytest44x: pytest>=4.4,<4.5
        pytest46x: pytest>=4.6,<4.7
        pytest50x: pytest>=5.0,<5.1
        pytest51x: pytest>=5.1,<5.2
+       pytest60x: pytest>=6.0,<6.1
+       pytest61x: pytest>=6.1,<6.2
 extras = test
 commands = py.test -vv --basetemp {envtmpdir}


### PR DESCRIPTION
This happens e.g. when a test fails without a trace via `pytest.fail(msg, pytrace=False)`.

Also adds unit test support for pytest 6.