### PR TITLE
Specifies that the encoding method for writing CSV files is UTF-8

### DIFF
--- a/pytest_csv/_reporter.py
+++ b/pytest_csv/_reporter.py
@@ -77,7 +77,7 @@ class CSVReporter(object):
                                               for header in six.iterkeys(row[column_id]))))
                    for column_id in six.iterkeys(self._columns)}
 
-        with open(self._csv_path, 'w', newline='') as out:
+        with open(self._csv_path, 'w', newline='', encoding="utf-8") as out:
             writer = csv.writer(out, delimiter=self._delimiter, quotechar=self._quote_char, quoting=csv.QUOTE_MINIMAL)
 
             writer.writerow([header


### PR DESCRIPTION
The UTF-8 is a more general encoding method.  Avoid exceptions caused by failure to encode and decode when writing CSV files.