### PR TITLE
add csv output sort using 'id' from column, with this solutions csv o…

### DIFF
--- a/pytest_csv/_plugin.py
+++ b/pytest_csv/_plugin.py
@@ -70,8 +70,7 @@ def pytest_addoption(parser):
     group.addoption(
         '--csv-xdist-sort',
         dest='csv_xdist_sort',
-        action='store',
-        metavar='xdist sort',
+        action='store_true',
         default= False,
         help='sort and match --co with xdist output in CSV files'
     )
@@ -83,10 +82,6 @@ def pytest_addhooks(pluginmanager):
 def pytest_configure(config):
     csv_path = config.option.csv_path
     if csv_path:
-        if config.option.csv_xdist_sort == 'True' or config.option.csv_xdist_sort == 'true':
-            csv_xdist_sort = bool(config.option.csv_xdist_sort)
-        else:
-            csv_xdist_sort = False
 
         columns_registry = dict(BUILTIN_COLUMNS_REGISTRY)
         config.hook.pytest_csv_register_columns(columns=columns_registry)
@@ -100,7 +95,7 @@ def pytest_configure(config):
                                            columns=columns,
                                            delimiter=config.option.csv_delimiter,
                                            quote_char=config.option.csv_quote_char,
-                                           xdist_sort= csv_xdist_sort)
+                                           xdist_sort= config.option.csv_xdist_sort)
         config.pluginmanager.register(config._csv_reporter)
 
 

--- a/pytest_csv/_plugin.py
+++ b/pytest_csv/_plugin.py
@@ -67,7 +67,14 @@ def pytest_addoption(parser):
         default='"',
         help='quoting character to use in CSV files'
     )
-
+    group.addoption(
+        '--csv-xdist-sort',
+        dest='csv_xdist_sort',
+        action='store',
+        metavar='xdist sort',
+        default= False,
+        help='sort and match --co with xdist output in CSV files'
+    )
 
 def pytest_addhooks(pluginmanager):
     pluginmanager.add_hookspecs(_hooks)
@@ -76,6 +83,11 @@ def pytest_addhooks(pluginmanager):
 def pytest_configure(config):
     csv_path = config.option.csv_path
     if csv_path:
+        if config.option.csv_xdist_sort == 'True' or config.option.csv_xdist_sort == 'true':
+            csv_xdist_sort = bool(config.option.csv_xdist_sort)
+        else:
+            csv_xdist_sort = False
+
         columns_registry = dict(BUILTIN_COLUMNS_REGISTRY)
         config.hook.pytest_csv_register_columns(columns=columns_registry)
 
@@ -87,7 +99,8 @@ def pytest_configure(config):
         config._csv_reporter = CSVReporter(csv_path=csv_path,
                                            columns=columns,
                                            delimiter=config.option.csv_delimiter,
-                                           quote_char=config.option.csv_quote_char)
+                                           quote_char=config.option.csv_quote_char,
+                                           xdist_sort= csv_xdist_sort)
         config.pluginmanager.register(config._csv_reporter)
 
 

--- a/pytest_csv/_reporter.py
+++ b/pytest_csv/_reporter.py
@@ -77,6 +77,11 @@ class CSVReporter(object):
                                               for header in six.iterkeys(row[column_id]))))
                    for column_id in six.iterkeys(self._columns)}
 
+        #find id column
+        scan_id_key = 'id'
+
+        id_index = list(headers.keys()).index(scan_id_key)  if "'"+ scan_id_key + "'" in str(headers.keys()) else -1
+
         with open(self._csv_path, 'w', newline='', encoding="utf-8") as out:
             writer = csv.writer(out, delimiter=self._delimiter, quotechar=self._quote_char, quoting=csv.QUOTE_MINIMAL)
 
@@ -84,11 +89,28 @@ class CSVReporter(object):
                              for column_id in six.iterkeys(self._columns)
                              for header in headers[column_id]])
 
-            for row in self._rows:
-                writer.writerow([row[column_id].get(header, '')
-                                 for column_id in six.iterkeys(self._columns)
-                                 for header in headers[column_id]])
+            if id_index == -1:
+                #if id column not founded
+                for row in self._rows:
+                    writer.writerow([row[column_id].get(header, '')
+                                    for column_id in six.iterkeys(self._columns)
+                                    for header in headers[column_id]])
+            else:
+                temp_lst = list()
+                session_lst = list()
+                for row in self._rows:
+                    #move csv data to temporary list
+                    temp_lst.append([row[column_id].get(header, '')
+                                    for column_id in six.iterkeys(self._columns)
+                                    for header in headers[column_id]])
 
+                # extract nodeid from sessions.items classes
+                for node in session.items:
+                    session_lst.append(node.nodeid)
+
+                # write the in-out-sync orders csv output
+                writer.writerows(sorted(temp_lst, key = lambda i:session_lst.index(i[id_index])))
+            
         session.config.hook.pytest_csv_written(csv_path=self._csv_path)
 
     def pytest_terminal_summary(self, terminalreporter):

--- a/pytest_csv/_reporter.py
+++ b/pytest_csv/_reporter.py
@@ -112,7 +112,7 @@ class CSVReporter(object):
 
                 # write the in-out-sync orders csv output
                 writer.writerows(sorted(temp_lst, key = lambda i:session_lst.index(i[id_index])))
-            
+
         session.config.hook.pytest_csv_written(csv_path=self._csv_path)
 
     def pytest_terminal_summary(self, terminalreporter):

--- a/pytest_csv/_reporter.py
+++ b/pytest_csv/_reporter.py
@@ -28,11 +28,13 @@ class CSVReporter(object):
                  csv_path,
                  columns,
                  delimiter,
-                 quote_char):
+                 quote_char,
+                 xdist_sort):
         self._csv_path = csv_path
         self._columns = columns
         self._delimiter = delimiter
         self._quote_char = quote_char
+        self._xdist_sort = xdist_sort
         self._rows = []
 
     @pytest.mark.hookwrapper
@@ -80,7 +82,7 @@ class CSVReporter(object):
         #find id column
         scan_id_key = 'id'
 
-        id_index = list(headers.keys()).index(scan_id_key)  if "'"+ scan_id_key + "'" in str(headers.keys()) else -1
+        id_index = list(headers.keys()).index(scan_id_key)  if f"'{scan_id_key}'" in str(headers.keys()) else -1
 
         with open(self._csv_path, 'w', newline='', encoding="utf-8") as out:
             writer = csv.writer(out, delimiter=self._delimiter, quotechar=self._quote_char, quoting=csv.QUOTE_MINIMAL)
@@ -89,8 +91,8 @@ class CSVReporter(object):
                              for column_id in six.iterkeys(self._columns)
                              for header in headers[column_id]])
 
-            if id_index == -1:
-                #if id column not founded
+            if id_index == -1 or self._xdist_sort is not True:
+                # if id column not founded
                 for row in self._rows:
                     writer.writerow([row[column_id].get(header, '')
                                     for column_id in six.iterkeys(self._columns)


### PR DESCRIPTION
add csv output sort using 'id' from column, with this solutions csv output will match --co. This solutions will change the default behavior:
1) When 'id' column is existed in user column, it will sort and match the order of the --co list with the csv output. The key reason is there no other parameters than 'id' column which able to match the --co data.
2) When 'id' column is not exited, the code will execute the default pytest-csv _reporter.py behavior. 