### PR TITLE
change from old-style mark to the new hookimpl decorator

### DIFF
--- a/pytest_csv/_reporter.py
+++ b/pytest_csv/_reporter.py
@@ -35,7 +35,7 @@ class CSVReporter(object):
         self._quote_char = quote_char
         self._rows = []
 
-    @pytest.mark.hookwrapper
+    @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_makereport(self, item, call):
         outcome = yield
         report = outcome.get_result()


### PR DESCRIPTION
When running with Python 3.9 (pytest 7.2.0), it complains about using the old-style mark option. I followed this link (https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers) to do the change which can resolve the warning message.